### PR TITLE
Beyond Storage v2.4.0 - Generator Refuel

### DIFF
--- a/BeyondStorage/BeyondStorage.csproj
+++ b/BeyondStorage/BeyondStorage.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Harmony\Item\Repair\ItemActionEntryRepair_Patches.cs"/>
     <Compile Include="Harmony\Item\Repair\XUiC_ItemActionList_Patches.cs"/>
     <Compile Include="Harmony\Item\XUiM_PlayerInventory_Patches.cs"/>
+    <Compile Include="Harmony\PowerSource\Refuel\XUiC_PowerSourceStats_Patches.cs"/>
     <Compile Include="Harmony\Reload\_3P\Animator3PRangedReloadState_Patches.cs"/>
     <Compile Include="Harmony\Reload\AnimatorCommon.cs"/>
     <Compile Include="Harmony\Reload\FP\AnimatorRangedReloadState_Patches.cs"/>
@@ -58,6 +59,7 @@
     <Compile Include="Scripts\ContainerLogic\Item\ItemCommon.cs"/>
     <Compile Include="Scripts\ContainerLogic\Item\ItemCraft.cs"/>
     <Compile Include="Scripts\ContainerLogic\Item\ItemRepair.cs"/>
+    <Compile Include="Scripts\ContainerLogic\PowerSource\PowerSourceRefuel.cs"/>
     <Compile Include="Scripts\ContainerLogic\Ranged\Ranged.cs"/>
     <Compile Include="Scripts\ContainerLogic\VehicleUtils.cs"/>
     <Compile Include="Scripts\ContainerLogic\Vehicle\VehicleRefuel.cs"/>

--- a/BeyondStorage/Harmony/PowerSource/Refuel/XUiC_PowerSourceStats_Patches.cs
+++ b/BeyondStorage/Harmony/PowerSource/Refuel/XUiC_PowerSourceStats_Patches.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using BeyondStorage.Scripts.Common;
+using BeyondStorage.Scripts.ContainerLogic.PowerSource;
+using HarmonyLib;
+using UniLinq;
+
+namespace BeyondStorage.PowerSource.Refuel;
+
+[HarmonyPatch(typeof(XUiC_PowerSourceStats))]
+public class XUiCPowerSourceStatsPatches {
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(XUiC_PowerSourceStats.BtnRefuel_OnPress))]
+#if DEBUG
+    [HarmonyDebug]
+#endif
+    private static IEnumerable<CodeInstruction> XUiC_PowerSourceStats_BtnRefuel_OnPress_Transpiler(IEnumerable<CodeInstruction> instructions) {
+        if (!BeyondStorage.Config.enableForGeneratorRefuel) return instructions;
+        var targetMethodString = $"{typeof(XUiC_PowerSourceStats)}.{nameof(XUiC_PowerSourceStats.BtnRefuel_OnPress)}";
+        LogUtil.Info($"Transpiling {targetMethodString}");
+        var codes = new List<CodeInstruction>(instructions);
+        var found = false;
+        for (var i = 0; i < codes.Count; i++) {
+            if (codes[i].opcode != OpCodes.Callvirt || (MethodInfo)codes[i].operand != AccessTools.Method(typeof(Bag), nameof(Bag.DecItem)))
+                continue;
+            if (LogUtil.IsDebug()) LogUtil.DebugLog($"Patching {targetMethodString}");
+            found = true;
+            List<CodeInstruction> newCode = [
+                // ldloc.s      _itemValue
+                codes[i - 5].Clone(),
+                // ldloc.s      _count2 (last removed count)
+                codes[i + 2].Clone(),
+                // ldloc.2      // _count1
+                new CodeInstruction(OpCodes.Ldloc_2),
+                // conv.i4      (int) _count1
+                new CodeInstruction(OpCodes.Conv_I4),
+                // PowerSourceRefuel.RefuelRemoveRemaining(ItemValue itemValue, int lastRemoved, int totalNeeded)
+                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PowerSourceRefuel), nameof(PowerSourceRefuel.RefuelRemoveRemaining))),
+                // stloc.s      _count2     |   update result
+                codes[i + 1].Clone()
+            ];
+            codes.InsertRange(i + 2, newCode);
+            break;
+        }
+
+        if (!found)
+            LogUtil.Error($"Failed to patch {targetMethodString}");
+        else
+            LogUtil.Info($"Successfully patched {targetMethodString}");
+
+        return codes.AsEnumerable();
+    }
+}

--- a/BeyondStorage/ModInfo.xml
+++ b/BeyondStorage/ModInfo.xml
@@ -2,7 +2,7 @@
 <xml>
   <Name value="BeyondStorage"/>
   <DisplayName value="Beyond Storage"/>
-  <Version value="2.3.0"/>
+  <Version value="2.4.0"/>
   <Description
     value="Utilize resources from distant storage for crafting, upgrading, and more! Originally 'CraftFromContainers' by aedenthorn."/>
   <Author value="aedenthorn, unv_Annihilator"/>

--- a/BeyondStorage/Scripts/Configuration/ModConfig.cs
+++ b/BeyondStorage/Scripts/Configuration/ModConfig.cs
@@ -25,6 +25,9 @@ internal static class ModConfig {
         // if set true nearby containers will be used for block upgrades
         public bool enableForBlockUpgrade = true;
 
+        // if set true will allow refueling generators
+        public bool enableForGeneratorRefuel = false;
+
         // if set true nearby containers will be used for item repairs
         // disable if you experience lag
         public bool enableForItemRepair = true;

--- a/BeyondStorage/Scripts/ContainerLogic/PowerSource/PowerSourceRefuel.cs
+++ b/BeyondStorage/Scripts/ContainerLogic/PowerSource/PowerSourceRefuel.cs
@@ -1,0 +1,22 @@
+﻿using BeyondStorage.Scripts.Common;
+
+namespace BeyondStorage.Scripts.ContainerLogic.PowerSource;
+
+public static class PowerSourceRefuel {
+    public static int RefuelRemoveRemaining(ItemValue itemValue, int lastRemoved, int totalNeeded) {
+#if DEBUG
+        if (LogUtil.IsDebug()) LogUtil.DebugLog("RefuelRemoveRemaining");
+#endif
+        // return early if we already have enough
+        if (lastRemoved == totalNeeded) return lastRemoved;
+        // update new required amount count removing last removed from total needed
+        var newReqCount = totalNeeded - lastRemoved;
+        // attempt to remove items from storage
+        var removedFromStorage = ContainerUtils.RemoveRemaining(itemValue, newReqCount);
+        if (LogUtil.IsDebug())
+            LogUtil.DebugLog(
+                $"RefuelRemoveRemaining - item {itemValue.ItemClass.GetItemName()}; lastRemoved {lastRemoved}; totalNeeded {totalNeeded}; newReqCount {newReqCount}; removedFromStorage {removedFromStorage}; updated result {lastRemoved + removedFromStorage}");
+        // add what removed from storage to last removed count
+        return lastRemoved + removedFromStorage;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 
 - Claims the rewards of challenges automatically after you complete them.
 
-### Beyond Storage [v2.3.0](https://github.com/unv-annihilator/7D2D_Mods/releases/tag/BeyondStorage_v2.3.0) - View on [Nexus Mods](https://www.nexusmods.com/7daystodie/mods/5087)
+### Beyond Storage [v2.4.0](https://github.com/unv-annihilator/7D2D_Mods/releases/tag/BeyondStorage_v2.4.0) - View on [Nexus Mods](https://www.nexusmods.com/7daystodie/mods/5087)
 
 - Originally 'CraftFromContainers' by aedenthorn. Refactored and updated for v1.0
 - Craft and/or Repair ITEMS using items from nearby storage. (Craft always on; Repair configurable defaults true)
 - Repair and/or Upgrade BLOCKS using items from nearby storage. (Configurable; defaults true)
 - Reload items (weapons) from nearby storage. (Configurable; defaults true)
 - Repair and/or Refuel VEHICLES using nearby storage. (Configurable; defaults false)
+- Refuel GENERATORS using nearby storage. (Configurable; defaults false)
 - Pulls from ALL nearby storage. (Fridges, drawers, storage chests, etc.) (Configurable; defaults false)
 - Pulls items from nearby VEHICLE STORAGE (Configurable; defaults false)
 - Range configurable in the configuration json file. (-1 is unlimited range; defaults -1)


### PR DESCRIPTION
Added option to allow refueling generators from nearby storage 
New Config 'enableForGeneratorRefuel' if set true allows refueling generators from storage (defaults false) 
Version bump
README.md updated